### PR TITLE
Update binary naming

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,10 @@ name = "angry_oxide"
 version = "0.1.0"
 edition = "2021"
 
+[[bin]]
+name = "angryoxide"
+path = "src/main.rs"
+
 [dependencies]
 nl80211-ng = { version = "0.1.1" }
 libwifi = { version = "0.3.1", path = "libs/libwifi" }


### PR DESCRIPTION
Allows package name to stay the same, but gives the binary a more traditional naming convention