### PR TITLE
Update devices.rs

### DIFF
--- a/src/devices.rs
+++ b/src/devices.rs
@@ -76,7 +76,7 @@ impl AuthSequence {
 // Trait to restrict WiFiDeviceList
 pub trait WiFiDeviceType {}
 
-trait HasSSID {
+pub trait HasSSID {
     fn ssid(&self) -> &Option<String>;
 }
 


### PR DESCRIPTION
Make HasSSID pub trait to mitigate "private trait `HasSSID` in public interface" error on compilation.