### PR TITLE
Fix a few clippy warnings, minor bugfixes/speed improvements

### DIFF
--- a/libs/libwifi/src/frame/components/station_info.rs
+++ b/libs/libwifi/src/frame/components/station_info.rs
@@ -560,11 +560,11 @@ pub enum WpsSetupState {
     Configured = 0x02,
 }
 
-impl ToString for WpsSetupState {
-    fn to_string(&self) -> String {
+impl fmt::Display for WpsSetupState {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            WpsSetupState::NotConfigured => "Not Configured".to_string(),
-            WpsSetupState::Configured => "Configured".to_string(),
+            WpsSetupState::NotConfigured => write!(f, "Not Configured"),
+            WpsSetupState::Configured => write!(f, "Configured"),
         }
     }
 }

--- a/libs/libwifi/src/parsers/components/station_info.rs
+++ b/libs/libwifi/src/parsers/components/station_info.rs
@@ -151,13 +151,13 @@ fn parse_wpa_information(data: &[u8]) -> Result<WpaInformation, &'static str> {
 }
 
 fn parse_ht_information(data: &[u8]) -> Result<HTInformation, &'static str> {
-    if data.len() < 1 {
+    if data.is_empty() {
         return Err("WPA Information data too short");
     }
 
     Ok(HTInformation {
-        primary_channel: data[0] as u8,
-        other_data: (&data[1..]).to_vec(),
+        primary_channel: data[0],
+        other_data: data[1..].to_vec(),
     })
 }
 

--- a/libs/pcap-file/src/common.rs
+++ b/libs/pcap-file/src/common.rs
@@ -1,4 +1,4 @@
-use byteorder_slice::{BigEndian, ByteOrder, LittleEndian};
+use byteorder_slice::ByteOrder;
 
 /// Timestamp resolution of the pcap
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
@@ -54,23 +54,6 @@ impl Endianness {
         return Endianness::Little;
     }
 }
-
-pub(crate) trait RuntimeByteorder: ByteOrder {
-    fn endianness() -> Endianness;
-}
-
-impl RuntimeByteorder for BigEndian {
-    fn endianness() -> Endianness {
-        Endianness::Big
-    }
-}
-
-impl RuntimeByteorder for LittleEndian {
-    fn endianness() -> Endianness {
-        Endianness::Little
-    }
-}
-
 
 /// Data link type
 ///

--- a/src/advancedtable/advtable.rs
+++ b/src/advancedtable/advtable.rs
@@ -648,8 +648,7 @@ impl<'a> AdvTable<'a> {
     ///
     /// Create a table that needs at least 30 columns to display.  Any extra space will be assigned
     /// to the last column.
-    #[cfg_attr(feature = "unstable", doc = " ```")]
-    #[cfg_attr(not(feature = "unstable"), doc = " ```ignore")]
+    /// ```ignore
     /// # use ratatui::layout::Constraint;
     /// # use ratatui::layout::SegmentSize;
     /// # use ratatui::widgets::Table;

--- a/src/attack.rs
+++ b/src/attack.rs
@@ -10,7 +10,7 @@ use libwifi::{
         components::{MacAddress, RsnAkmSuite, RsnCipherSuite, RsnInformation},
         Beacon, DeauthenticationReason, ProbeRequest,
     },
-    parse_frame, Addresses, Frame,
+    Addresses,
 };
 use nl80211_ng::channels::WiFiBand;
 
@@ -638,7 +638,7 @@ pub fn rogue_m2_attack_directed(
             &probe.header.address_1,
             &ssid,
             oxide.counters.sequence3(),
-            oxide.if_hardware.current_channel.try_into().unwrap(),
+            oxide.if_hardware.current_channel,
         );
         write_packet(oxide.raw_sockets.tx_socket.as_raw_fd(), &frx)?;
         station.interactions += 1;

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -186,14 +186,11 @@ impl FourWayHandshake {
     }
 
     pub fn is_wpa3(&self) -> bool {
-        if let Some(rsn) = self.rsn_type.clone() {
-            if rsn == vec![RsnAkmSuite::SAE] {
-                return true;
-            } else {
-                return false;
-            }
+        if let Some(rsn) = &self.rsn_type {
+            rsn == &[RsnAkmSuite::SAE]
+        } else {
+            false
         }
-        false
     }
 
     pub fn written(&self) -> bool {

--- a/src/eventhandler.rs
+++ b/src/eventhandler.rs
@@ -91,7 +91,7 @@ impl EventHandler {
                         let _ = match mouse.kind {
                             MouseEventKind::ScrollDown => tx.send(EventType::Key(event)),
                             MouseEventKind::ScrollUp => tx.send(EventType::Key(event)),
-                            _ => Ok({}),
+                            _ => Ok(()),
                         };
                     }
                 }

--- a/src/gps.rs
+++ b/src/gps.rs
@@ -327,11 +327,11 @@ impl Timestamp {
         Ok(Timestamp { high, low })
     }
 
-    pub fn to_u64(&self) -> u64 {
+    pub fn to_u64(self) -> u64 {
         ((self.high as u64) << 32) | self.low as u64
     }
 
-    pub fn to_system_time(&self) -> SystemTime {
+    pub fn to_system_time(self) -> SystemTime {
         UNIX_EPOCH + Duration::from_secs(self.to_u64())
     }
 }
@@ -350,7 +350,7 @@ impl FixedPoint {
         }
     }
 
-    pub fn to_f64(&self) -> f64 {
+    pub fn to_f64(self) -> f64 {
         let divisor = 10u64.pow(self.decimal_places) as f64;
         self.value as f64 / divisor
     }
@@ -364,7 +364,7 @@ pub struct Fixed3_7 {
 impl Fixed3_7 {
     // Converts from a floating-point number to a Fixed3_7 representation
     pub fn from_float(flt: f64) -> Result<Self, &'static str> {
-        if flt < -180.0 || flt > 180.0 {
+        if !(-180.0..=180.0).contains(&flt) {
             return Err("invalid value"); // Out of range values are considered illegal
         }
 
@@ -375,7 +375,7 @@ impl Fixed3_7 {
     }
 
     // Converts the Fixed3_7 back to a floating-point number
-    pub fn to_float(&self) -> f64 {
+    pub fn to_float(self) -> f64 {
         if self.value > 3600000000 {
             panic!("Value too much");
         }
@@ -391,7 +391,7 @@ pub struct Fixed3_6 {
 
 impl Fixed3_6 {
     pub fn from_float(flt: f64) -> Result<Self, &'static str> {
-        if flt < 0.0 || flt > 999.999999 {
+        if !(0.0..=999.999999).contains(&flt) {
             return Err("invalid value"); // Out of range values are considered illegal
         }
         let scaled = (flt * 1_000_000.0) as u32; // Rounding done on f64
@@ -399,7 +399,7 @@ impl Fixed3_6 {
     }
 
     // Converts the Fixed3_6 back to a floating-point number
-    pub fn to_float(&self) -> f64 {
+    pub fn to_float(self) -> f64 {
         self.value as f64 / 1_000_000.0
     }
 }
@@ -419,7 +419,7 @@ impl Fixed6_4 {
         Ok(Fixed6_4 { value: scaled })
     }
 
-    pub fn to_float(&self) -> f64 {
+    pub fn to_float(self) -> f64 {
         (self.value as i64 - 18_000_000 * 10_000) as f64 / 10_000.0
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -501,16 +501,10 @@ impl OxideRuntime {
                         let target = match line {
                             Ok(l) => {
                                 // Remove comments
-                                let line = if let Some(index) = l.find('#') {
-                                    let line_without_comment = &l[..index];
-                                    line_without_comment
-                                } else {
-                                    &l
-                                };
-                                let _ = line.trim_end();
-                                match MacAddress::from_str(&line) {
+                                let line = util::strip_comment(&l);
+                                match MacAddress::from_str(line) {
                                     Ok(mac) => Target::MAC(TargetMAC::new(mac)),
-                                    Err(_) => Target::SSID(TargetSSID::new(&line)),
+                                    Err(_) => Target::SSID(TargetSSID::new(line)),
                                 }
                             }
                             Err(_) => {
@@ -598,15 +592,8 @@ impl OxideRuntime {
 
                         let white = match line {
                             Ok(l) => {
-                                // Remove comments
-                                let line = if let Some(index) = l.find('#') {
-                                    let line_without_comment = &l[..index];
-                                    line_without_comment
-                                } else {
-                                    &l
-                                };
-                                let _ = line.trim_end();
-                                match MacAddress::from_str(&line) {
+                                let line = util::strip_comment(&l);
+                                match MacAddress::from_str(line) {
                                     Ok(mac) => {
                                         if targ_list.is_actual_target_mac(&mac) {
                                             println!("❌ Whitelist {} is a target. Cannot add to whitelist.", mac);
@@ -616,7 +603,7 @@ impl OxideRuntime {
                                         }
                                     }
                                     Err(_) => {
-                                        if targ_list.is_actual_target_ssid(&line) {
+                                        if targ_list.is_actual_target_ssid(line) {
                                             println!("❌ Whitelist {} is a target. Cannot add to whitelist.", line);
                                             continue;
                                         } else {

--- a/src/tabbedblock/tabbedblock.rs
+++ b/src/tabbedblock/tabbedblock.rs
@@ -317,7 +317,7 @@ impl<'a> TabbedBlock<'a> {
     /// The following example demonstrates:
     /// - Default tab alignment
     /// - Multiple tabs (notice "Center" is centered according to the full with of the TabbedBlock, not
-    /// the leftover space)
+    ///   the leftover space)
     /// - Two tabs with the same alignment (notice the left tabs are separated)
     /// ```
     /// use ratatui::{

--- a/src/targets.rs
+++ b/src/targets.rs
@@ -179,7 +179,7 @@ impl TargetList {
                 }
             }
         }
-        return matches;
+        matches
     }
 
     pub fn is_actual_target_mac(&self, mac: &MacAddress) -> bool {

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -785,7 +785,7 @@ fn create_ap_page(oxide: &mut OxideRuntime, frame: &mut Frame<'_>, area: Rect) {
                 Line::from(vec![
                     Span::from("Make: "),
                     Span::from(ap.wps_data.as_ref().map_or("Unknown".to_string(), |f| {
-                        let str = format!("{}", f.manufacturer);
+                        let str = f.manufacturer.to_string();
                         if str.is_empty() {
                             "Unknown".to_string()
                         } else {
@@ -796,7 +796,7 @@ fn create_ap_page(oxide: &mut OxideRuntime, frame: &mut Frame<'_>, area: Rect) {
                 Line::from(vec![
                     Span::from("Device Name: "),
                     Span::from(ap.wps_data.as_ref().map_or("Unknown".to_string(), |f| {
-                        let str = format!("{}", f.device_name);
+                        let str = f.device_name.to_string();
                         if str.is_empty() {
                             "Unknown".to_string()
                         } else {
@@ -807,7 +807,7 @@ fn create_ap_page(oxide: &mut OxideRuntime, frame: &mut Frame<'_>, area: Rect) {
                 Line::from(vec![
                     Span::from("Device Type: "),
                     Span::from(ap.wps_data.as_ref().map_or("Unknown".to_string(), |f| {
-                        let str = format!("{}", f.primary_device_type);
+                        let str = f.primary_device_type.to_string();
                         if str.is_empty() {
                             "Unknown".to_string()
                         } else {
@@ -867,14 +867,11 @@ fn create_ap_page(oxide: &mut OxideRuntime, frame: &mut Frame<'_>, area: Rect) {
                             height: 1,
                         });
                     let cl = Paragraph::new(format!(" {}{}", icon, client.mac_address));
-                    let last = Paragraph::new(format!("{}", epoch_to_string(client.last_recv)));
-                    let rssi = Paragraph::new(format!(
-                        "{}",
-                        match client.last_signal_strength.value {
-                            0 => "".to_string(),
-                            _ => client.last_signal_strength.value.to_string(),
-                        }
-                    ));
+                    let last = Paragraph::new(epoch_to_string(client.last_recv));
+                    let rssi = Paragraph::new(match client.last_signal_strength.value {
+                        0 => "".to_string(),
+                        _ => client.last_signal_strength.value.to_string(),
+                    });
                     let tx = Paragraph::new(format!("{}", client.interactions));
                     frame.render_widget(cl, row_layout[0]);
                     frame.render_widget(last, row_layout[1]);

--- a/src/util.rs
+++ b/src/util.rs
@@ -2,6 +2,7 @@ use chrono::{DateTime, Utc};
 use libwifi::frame::components::WpsInformation;
 use libwifi::frame::{EapolKey, KeyInformation};
 use radiotap::field::ext::TimeUnit;
+use std::fmt::Write;
 use std::fs::File;
 use std::io;
 use std::net::IpAddr;
@@ -28,7 +29,10 @@ pub fn epoch_to_string(epoch: u64) -> String {
 }
 
 pub fn slice_to_hex_string(bytes: &[u8]) -> String {
-    bytes.iter().map(|b| format!("{:02x}", b)).collect()
+    bytes.iter().fold(String::new(), |mut output, b| {
+        let _ = write!(output, "{b:02x}");
+        output
+    })
 }
 
 pub fn epoch_to_iso_string(epoch: u64) -> String {
@@ -198,6 +202,13 @@ pub fn sanitize_essid(filename: &str) -> String {
         .collect()
 }
 
+pub fn strip_comment(line: &str) -> &str {
+    line.split_once('#')
+        .map(|(line_without_comment, _)| line_without_comment)
+        .unwrap_or(line)
+        .trim_end()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -221,5 +232,13 @@ mod tests {
                 input
             );
         }
+    }
+
+    #[test]
+    fn test_strip_comment() {
+        assert_eq!(strip_comment("hello world"), "hello world");
+        assert_eq!(strip_comment("hello # world"), "hello");
+        assert_eq!(strip_comment("hello # world # test"), "hello");
+        assert_eq!(strip_comment("hello   "), "hello");
     }
 }

--- a/src/whitelist.rs
+++ b/src/whitelist.rs
@@ -179,7 +179,7 @@ impl WhiteList {
                 }
             }
         }
-        return matches;
+        matches
     }
 
     pub fn is_whitelisted_mac(&self, mac: &MacAddress) -> bool {


### PR DESCRIPTION
Some minor improvements:

- make is_wpa3 allocation free
- improve slice_to_hex_string speed by reducing number of allocations needed
- fix bug related to comment stripping
- some types that are Copy can be passed without a `&` borrow
- use .contains instead of manual range compare
- remove some unneeded explicit returns

I noticed the readme says "AngryOxide was developed as a way to learn Rust, [...]" but I found the code very pleasant to work with, well done. :)