### PR TITLE
fix: correct 'occured' to 'occurred' typo in user-facing error message

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -2178,7 +2178,7 @@ fn process_frame(oxide: &mut OxideRuntime, packet: &[u8]) -> Result<(), String> 
         Err(err) => {
             match err {
                 libwifi::error::Error::Failure(message, _data) => match &message[..] {
-                    "An error occured while parsing the data: nom::ErrorKind is Eof" => {}
+                    "An error occurred while parsing the data: nom::ErrorKind is Eof" => {}
                     _ => {
                         oxide.status_log.add_message(StatusMessage::new(
                             MessageType::Error,


### PR DESCRIPTION
## Summary
Fix user-facing error message typo in `src/main.rs:2181`:

**Before:** `An error occured while parsing the data: nom::ErrorKind is Eof`
**After:** `An error occurred while parsing the data: nom::ErrorKind is Eof`

## Why
This error message is shown to users when parsing fails during network handshake. Fixing the typo improves user experience.